### PR TITLE
Remove Bluebird & coffee-script as runtime dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.iml
 .idea
+dist/

--- a/index.js
+++ b/index.js
@@ -2,12 +2,8 @@
 /* jshint -W097 */
 'use strict';
 
-
-var coffee = require('coffee-script');
-coffee.register();
-
-module.exports = require('./lib/promiseFtp');
+module.exports = require('./dist/promiseFtp');
 module.exports.FtpConnectionError = require('promise-ftp-common').FtpConnectionError;
 module.exports.FtpReconnectError = require('promise-ftp-common').FtpReconnectError;
 module.exports.STATUSES = require('promise-ftp-common').STATUSES;
-module.exports.ERROR_CODES = require('./lib/errorCodes');
+module.exports.ERROR_CODES = require('./dist/errorCodes');

--- a/lib/promiseFtp.coffee
+++ b/lib/promiseFtp.coffee
@@ -187,7 +187,7 @@ class PromiseFtp
     commonLogicFactory = (name, handler) ->
       promisifiedClientMethods[name] = (args...) ->
         new Promise (resolve, reject) ->
-          client[name] (err, res) ->
+          client[name] args..., (err, res) ->
             if err then reject err else resolve(res)
       if !handler
         handler = promisifiedClientMethods[name]

--- a/lib/promiseFtp.coffee
+++ b/lib/promiseFtp.coffee
@@ -105,7 +105,7 @@ class PromiseFtp
       
     # methods listed in otherPrototypeMethods, which don't get a wrapper
     
-    @connect = (options) -> Promise.try () ->
+    @connect = (options) -> Promise.resolve().then () ->
       if connectionStatus != STATUSES.NOT_YET_CONNECTED && connectionStatus != STATUSES.DISCONNECTED
         throw new FtpConnectionError("can't connect when connection status is: '#{connectionStatus}'")
       # copy options object so options can't change without another call to @connect()
@@ -125,7 +125,7 @@ class PromiseFtp
       # now that everything is set up, we can connect
       _connect(STATUSES.CONNECTING)
   
-    @reconnect = () -> Promise.try () ->
+    @reconnect = () -> Promise.resolve().then () ->
       if connectionStatus != STATUSES.NOT_YET_CONNECTED && connectionStatus != STATUSES.DISCONNECTED
         throw new FtpConnectionError("can't reconnect when connection status is: '#{connectionStatus}'")
       _connect(STATUSES.RECONNECTING)
@@ -185,11 +185,14 @@ class PromiseFtp
     
     # common promise, connection-check, and reconnect logic
     commonLogicFactory = (name, handler) ->
-      promisifiedClientMethods[name] = Promise.promisify(client[name], client)
+      promisifiedClientMethods[name] = (args...) ->
+        new Promise (resolve, reject) ->
+          client[name] (err, res) ->
+            if err then reject err else resolve(res)
       if !handler
         handler = promisifiedClientMethods[name]
       (args...) ->
-        Promise.try () =>
+        Promise.resolve().then () =>
           # if we need to reconnect and we're not already reconnecting, start reconnect
           if unexpectedClose && autoReconnect && !autoReconnectPromise
             autoReconnectPromise = _connect(STATUSES.RECONNECTING)

--- a/lib/promiseFtp.coffee
+++ b/lib/promiseFtp.coffee
@@ -4,7 +4,6 @@
 
 
 FtpClient = require('ftp')
-Promise = require('bluebird')
 path = require('path')
 
 FtpConnectionError = require('promise-ftp-common').FtpConnectionError

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "Joe Ibershoff <joe@realtymaps.com>",
     "Moti Zilberman <motiz88@gmail.com>"
   ],
-  "directories": {
-    "dist": "./dist"
-  },
+  "files": [
+    "dist",
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/realtymaps/promise-ftp"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "author": "RealtyMaps",
   "contributors": [
-    "Joe Ibershoff <joe@realtymaps.com>"
+    "Joe Ibershoff <joe@realtymaps.com>",
+    "Moti Zilberman <motiz88@gmail.com>"
   ],
   "directories": {
-    "lib": "./lib"
+    "dist": "./dist"
   },
   "repository": {
     "type": "git",
@@ -21,9 +22,10 @@
     "node"
   ],
   "dependencies": {
-    "bluebird": "2.x",
-    "coffee-script": "1.x",
     "ftp": "0.3.10"
+  },
+  "devDependencies": {
+    "coffee-script": "1.x"
   },
   "peerDependencies": {
     "promise-ftp-common": "^1.1.2"
@@ -31,5 +33,13 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/realtymaps/promise-ftp/issues"
+  },
+  "engines": {
+    "node": ">=0.11.13",
+    "iojs": "*"
+  },
+  "scripts": {
+    "build": "coffee --compile --output dist/ lib/",
+    "dev": "coffee --watch --output dist lib/"
   }
 }


### PR DESCRIPTION
This sets up the package to be published to npm as plain JS and to use global/native Promises rather than bundle Bluebird.

See also the master branches of my forks of `promise-ftp`(`-common`), which I have published as versions 2.0.7 and 2.0.2 of [@motiz88/promise-ftp](https://www.npmjs.com/package/@motiz88/promise-ftp) and [@motiz88/promise-ftp-common](https://www.npmjs.com/package/@motiz88/promise-ftp-common) respectively.