### PR TITLE
Remove reference to Bluebird in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module is a wrapper around the [node-ftp](https://github.com/mscdex/node-ft
 features as well as a convenient promise-based API.
 
 This library is written primarily in CoffeeScript, but may be used just as easily in a Node app using Javascript or
-CoffeeScript.  Promises in this module are provided by [Bluebird](https://github.com/petkaantonov/bluebird).
+CoffeeScript.  [Native promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) are used in this module.
 
 
 Change Log


### PR DESCRIPTION
It looks like Bluebird was removed in this [PR](https://github.com/realtymaps/promise-ftp/pull/1). There is some additional discussion there but unless you go searching for it it's not immediately clear that bluebird (and the related functionality it provides) is not available.