### PR TITLE
Add back Bluebird as the promise library

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node"
   ],
   "dependencies": {
+    "bluebird": "2.x",
     "ftp": "0.3.10",
     "promise-ftp-common": "^1.1.5"
   },


### PR DESCRIPTION
This PR adds back Bluebird as the promise library per the discussion at https://github.com/realtymaps/promise-ftp/pull/16.