### PR TITLE
Updating bluebird and ftp dependencies

### DIFF
--- a/lib/promiseFtp.coffee
+++ b/lib/promiseFtp.coffee
@@ -3,7 +3,7 @@
 'use strict'
 
 
-FtpClient = require('ftp')
+FtpClient = require('@icetee/ftp')
 Promise = require('bluebird')
 path = require('path')
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node"
   ],
   "dependencies": {
-    "bluebird": "^3.5.0",
+    "bluebird": "2.x",
     "@icetee/ftp": "^0.3.15",
     "promise-ftp-common": "^1.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "RealtyMaps",
   "contributors": [
     "Joe Ibershoff <joe@realtymaps.com>",
-    "Moti Zilberman <motiz88@gmail.com>"
+    "Moti Zilberman <motiz88@gmail.com>",
+    "Gabe Martin <gabema@gmail.com>"
   ],
   "files": [
     "dist",
@@ -23,8 +24,8 @@
     "node"
   ],
   "dependencies": {
-    "bluebird": "2.x",
-    "ftp": "0.3.10",
+    "bluebird": "^3.5.0",
+    "@icetee/ftp": "^0.3.15",
     "promise-ftp-common": "^1.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
The node-ftp project appears to have become a dead project unfortunately and the most actively maintained and popular fork appears to be icetee/node-ftp.  Updating the ftp dependency includes some very useful fixes that have been withering on the vine but are sorely needed.  Also updated the bluebird version to the latest version.

Note: I haven't tested the changes other than to ensure it builds. Could use some help with that.  No tests in this project.