### PR TITLE
Remove promise-ftp-common from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
   "devDependencies": {
     "coffee-script": "1.x"
   },
-  "peerDependencies": {
-    "promise-ftp-common": "^1.1.5"
-  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/realtymaps/promise-ftp/issues"


### PR DESCRIPTION
It shouldn't need to be specified in both dependencies and peerDependencies.