### PR TITLE
logout issues QUIT command

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ false. Returned promise resolves to _undefined_.
 * **rename**(oldPath <_string_>, newPath <_string_>): Renames/moves `oldPath` to `newPath` on the server. Returned
 promise resolves to _undefined_.
 
-* **logout**(): Logs the user out from the server. Returned promise resolves to _undefined_.
+* **logout**(): Logs the user out from the server with QUIT command. Returned promise resolves to _undefined_.
 
 * **delete**(path <_string_>): Deletes the file at `path`. Returned promise resolves to _undefined_.
 

--- a/lib/promiseFtp.coffee
+++ b/lib/promiseFtp.coffee
@@ -33,6 +33,7 @@ simplePassthroughMethods = [
   'size'
   'lastMod'
   'restart'
+  'logout'
 ]
 
 # these methods will have custom logic defined, and then will be wrapped in common promise, connection-check, and
@@ -47,7 +48,6 @@ complexPassthroughMethods = [
 otherPrototypeMethods = [
   'connect'
   'reconnect'
-  'logout'
   'end'
   'destroy'
   'getConnectionStatus'


### PR DESCRIPTION
When we try to call logout using this library it does not call the QUIT command because the logout method is not available. This adds `logout` to `simplePassthroughMethods` so that it's available to call when we fire logout()