### PR TITLE
Update package.json -> Update @icetee/ftp

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "bluebird": "2.x",
-    "@icetee/ftp": "^0.3.15",
+    "@icetee/ftp": "^1.0.8",
     "promise-ftp-common": "^1.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Update requirement for @icetee/ftp to ^1.0.8

This fixes the issue for the reentry function not being implemented for ftps connections. 